### PR TITLE
Add Docker build / run instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+*.md
+conf
+init
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.4
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+VOLUME /conf
+
+RUN pip3 install --no-cache-dir \
+  astral \
+  configparser \
+  daemonize \
+  sseclient
+
+# TODO
+# COPY requirements.txt requirements.txt
+# RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Copy source
+COPY . .
+
+CMD [ "/usr/local/bin/python", "/usr/src/app/bin/appdaemon.py", "/conf/appdaemon.cfg" ]

--- a/README.md
+++ b/README.md
@@ -17,9 +17,15 @@ Change your working directory to the repository root. Moving forward, we will be
 $ cd appdaemon
 ```
 
-# Install Prereqs
+# Install using Docker
 
-Before running `AppDaemon` you will need to add some python prerequisites:
+``` bash
+$ docker build -t appdaemon .
+```
+
+# Install locally
+
+Before running `AppDaemon` locally you will need to add some python prerequisites:
 
 ```bash
 $ sudo pip3 install daemonize
@@ -39,6 +45,8 @@ This can be fixed with:
 ```
 $ sudo pip3 install --upgrade requests
 ```
+
+# Configuration
 
 When you have all the prereqs in place, edit the `[AppDaemon]` section of the conf/appdaemon.cfg file to reflect your environment:
 
@@ -66,7 +74,52 @@ timezone = <timezone>
 
 The other sections of the file relate to App configuration and are described in the [API doc](API.md).
 
-You can then run AppDaemon from the command line as follows:
+# Running
+
+## Docker
+
+Our Docker image is designed to load your configuration and apps from a volume at `/conf` so that you can manage them in your own git repository.
+
+For example, if you have a local repository in `/Users/foo/ha-config` containing the following files:
+
+```bash
+$ git ls-files
+configuration.yaml
+customize.yaml
+known_devices.yaml
+appdaemon.cfg
+apps
+apps/magic.py
+```
+
+And a `appdaemon.cfg` file that pointed to these apps in `/conf/apps`:
+
+```
+[AppDaemon]
+ha_url = <some_url>
+ha_key = <some key>
+logfile = /var/log/AppDaemon.log
+errorfile = /var/log/error.log
+app_dir = /conf/apps
+threads = 10
+latitude = <latitude>
+longitude = <longitude>
+elevation = <elevation
+timezone = <timezone>
+```
+
+You can then run AppDaemon in Docker like so:
+
+```bash
+$ docker run -d -v $(pwd)/conf:/conf --name appdaemon appdaemon:latest
+$ docker logs appdaemon
+2016-08-21 14:18:04,367 INFO Got initial state
+2016-08-21 14:18:04,371 INFO Loading Module: /conf/apps/magic.py
+```
+
+## Directly
+
+You can run AppDaemon from the command line as follows:
 
 ```bash
 $ ./bin/appdaemon.py conf/appdaemon.cfg


### PR DESCRIPTION
Adds a Dockerfile and documents how to use it. 

tl;dr:

```bash
~/src/appdaemon (docker) 
$ docker build -t appdaemon .
Sending build context to Docker daemon 50.18 kB
Step 1 : FROM python:3.4
 ---> 93bc8e41eb8c
Step 2 : RUN mkdir -p /usr/src/app
 ---> Using cache
 ---> bdb71898d80e
Step 3 : WORKDIR /usr/src/app
 ---> Using cache
 ---> 5817bdb6fa26
Step 4 : VOLUME /conf
 ---> Using cache
 ---> f850f982963f
Step 5 : RUN pip3 install --no-cache-dir   astral   configparser   daemonize   sseclient
 ---> Using cache
 ---> 5da7377daf33
Step 6 : COPY . .
 ---> Using cache
 ---> d1af06f395c1
Step 7 : CMD /usr/local/bin/python /usr/src/app/bin/appdaemon.py /conf/appdaemon.cfg
 ---> Using cache
 ---> c7c207563b2b
Successfully built c7c207563b2b
~/src/appdaemon (docker) 
$ ls /Users/jnewland/src/ha-config/appdaemon.cfg /Users/jnewland/src/ha-config/apps/*.py
/Users/jnewland/src/ha-config/appdaemon.cfg	/Users/jnewland/src/ha-config/apps/magic.py
~/src/appdaemon (docker) 
$ docker run -d -v /Users/jnewland/src/ha-config:/conf --name appdaemon appdaemon:latest
4a069bb9ad16e367617158a9ec04232e7e141541ba3d330156a163834e6b6330
~/src/appdaemon (docker) 
$ docker logs -ft appdaemon
2016-08-21T14:33:01.360162177Z 2016-08-21 14:33:01,359 INFO Got initial state
2016-08-21T14:33:01.364242752Z 2016-08-21 14:33:01,363 INFO Loading Module: /conf/apps/magic.py
^C
~/src/appdaemon (docker) 
$ docker stop appdaemon
appdaemon
```